### PR TITLE
Type annotation for model argument of view

### DIFF
--- a/minimal/src/App.fs
+++ b/minimal/src/App.fs
@@ -29,7 +29,7 @@ let update (msg:Msg) (model:Model) =
 
 // VIEW (rendered with React)
 
-let view model dispatch =
+let view (model:Model) dispatch =
 
   div []
       [ button [ OnClick (fun _ -> dispatch Increment) ] [ str "+" ]


### PR DESCRIPTION
Developing with this sample as a base, I wondered why I had to use the dynamic lookup operator on the model. Adding the type annotation avoids this.